### PR TITLE
Fix Flaky Test testToString

### DIFF
--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -705,17 +705,19 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         map.put((K) "B", (V) "U");
         map.put((K) "B", (V) "V");
         map.put((K) "B", (V) "W");
+        String mapToString = map.toString();
         assertTrue(
-            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
-            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(mapToString) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(mapToString)
         );
 
         final MultiValuedMap<K, V> originalNull = null;
         assertThrows(NullPointerException.class, () -> map.putAll(originalNull),
                 "expecting NullPointerException");
+        mapToString = map.toString();
         assertTrue(
-            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
-            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(mapToString) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(mapToString)
         );
 
         map.remove("A");


### PR DESCRIPTION
## PR Overview:
This PR fixes the following tests- 

- [org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest.testToString](https://github.com/kevin952/commons-collections/blob/af6fff168cc253e82b4b6fcf17be04ebfd6e2b44/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L697)
- [org.apache.commons.collections4.multimap.HashSetValuedHashMapTest.testToString](https://github.com/kevin952/commons-collections/blob/af6fff168cc253e82b4b6fcf17be04ebfd6e2b44/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L697)

- [org.apache.commons.collections4.multimap.ArrayListValuedHashMapTest.testToString](https://github.com/kevin952/commons-collections/blob/af6fff168cc253e82b4b6fcf17be04ebfd6e2b44/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L697)
## Test Overview:
The function `testToString` tests how a `MultiValuedMap` works. A `MultiValuedMap` is basically a map with a key value that can associate itself to either a single value or multiple values (Collections). In this example a key is mapped to one value.

You can reproduce the issue by running the following commands (below command is for `testToString` in `TransformedMultiValuedMapTest`, please change class name for targeting other implementations of `testToString`) -
```
mvn install -pl . -am -DskipTests
mvn  -Dtest=org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest#testToString
mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest#testToString
```
## Problem
A multivalued map when being called will not maintain the order of values, the keys may be rearranged in any order. The function, `map.toString()` will return a new instance of a map every time so the following line makes the test flaky. This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC
https://github.com/anirudh711/commons-collections/blob/35e408717379eed0085cdb29e879209dbadc1ead/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java#L45-L48
https://github.com/anirudh711/commons-collections/blob/35e408717379eed0085cdb29e879209dbadc1ead/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L708-L711

Here the  `map.toString()` might return `{B=[U, V, W], A=[X, Y, Z]}` for the LHS and `{A=[X, Y, Z], B=[U, V, W]}` for the RHS. 
The toString() function is not inherently flaky and thus is not the root cause of the issue. The initialization of MultiValuedMap with `makeObject()` is what causes the issue as this can change the order of the keys.

## Fix:
https://github.com/anirudh711/commons-collections/blob/0caebd3aa4bc0eb86f727185f5690076045c9176/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L708-L712
Instead of calling a new instance of `map.toString()`, we can assign it to a variable commonly and use it making the value constant for the entire test. This fix will avoid re-initializing the map thus reordering the values in the map.

This PR provides a fix on the abstract class and hence provides a fix for the class with tests that implement this class. 

